### PR TITLE
Custom field validation: Bug Fixes

### DIFF
--- a/src/components/CustomField.jsx
+++ b/src/components/CustomField.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Text, View } from 'react-native';
 import { Icon } from 'react-native-elements';
 import screens from '../constants/screens';
@@ -13,6 +13,13 @@ export default function CustomField({ id, required, name, ...rest }) {
   const displayName = (schema && schema.label) || name;
   const description = (schema && schema.description) || '';
 
+  const [submitAttempts, setSubmitAttempts] = useState(props.submitCount);
+
+  // console.log(props.touched.customFields);
+  // console.log(props.errors.customFields);
+  // console.log(props);
+  // console.log('SUBMIT COUNT:' + submitAttempts);
+
   //separate style for boolean custom fields
   if (schema.displayType === 'boolean') {
     return (
@@ -22,7 +29,11 @@ export default function CustomField({ id, required, name, ...rest }) {
             {displayName}
             {required && '*'}
           </Text>
-          {props.touched.customFields &&
+          {/* {props.touched.customFields &&
+            props.touched.customFields[name] &&
+            props.errors.customFields &&
+            props.errors.customFields[name] && ( */}
+          {props.submitCount > submitAttempts &&
             props.errors.customFields &&
             props.errors.customFields[name] && (
               <Typography
@@ -56,7 +67,11 @@ export default function CustomField({ id, required, name, ...rest }) {
           {displayName}
           {required && '*'}
         </Text>
-        {props.touched.customFields &&
+        {/* {props.touched.customFields &&
+          props.touched.customFields[name] &&
+          props.errors.customFields &&
+          props.errors.customFields[name] && ( */}
+        {props.submitCount > submitAttempts &&
           props.errors.customFields &&
           props.errors.customFields[name] && (
             <Typography

--- a/src/components/CustomField.jsx
+++ b/src/components/CustomField.jsx
@@ -15,11 +15,6 @@ export default function CustomField({ id, required, name, ...rest }) {
 
   const [submitAttempts, setSubmitAttempts] = useState(props.submitCount);
 
-  // console.log(props.touched.customFields);
-  // console.log(props.errors.customFields);
-  // console.log(props);
-  // console.log('SUBMIT COUNT:' + submitAttempts);
-
   //separate style for boolean custom fields
   if (schema.displayType === 'boolean') {
     return (
@@ -29,10 +24,6 @@ export default function CustomField({ id, required, name, ...rest }) {
             {displayName}
             {required && '*'}
           </Text>
-          {/* {props.touched.customFields &&
-            props.touched.customFields[name] &&
-            props.errors.customFields &&
-            props.errors.customFields[name] && ( */}
           {props.submitCount > submitAttempts &&
             props.errors.customFields &&
             props.errors.customFields[name] && (
@@ -67,10 +58,6 @@ export default function CustomField({ id, required, name, ...rest }) {
           {displayName}
           {required && '*'}
         </Text>
-        {/* {props.touched.customFields &&
-          props.touched.customFields[name] &&
-          props.errors.customFields &&
-          props.errors.customFields[name] && ( */}
         {props.submitCount > submitAttempts &&
           props.errors.customFields &&
           props.errors.customFields[name] && (

--- a/src/constants/testSettingsPacket.js
+++ b/src/constants/testSettingsPacket.js
@@ -146,6 +146,20 @@ export default {
           type: 'string',
           required: true,
         },
+        // {
+        //   schema: {
+        //     description: 'date input',
+        //     label: 'Date Input',
+        //     category: '661661cd-a017-4796-ac4b-16a40b869daf',
+        //   },
+        //   displayType: 'date',
+        //   name: 'DATE',
+        //   multiple: false,
+        //   className: 'org.ecocean.MarkedIndividual',
+        //   id: 'c32e690c-e308-4362-82d5-bc97579e0abc',
+        //   type: 'string',
+        //   required: true,
+        // },
         {
           schema: {
             displayType: 'string',
@@ -174,7 +188,7 @@ export default {
           className: 'org.ecocean.MarkedIndividual',
           id: '1b62470c-890e-4665-8153-6ebefce10d189',
           type: 'double',
-          required: true,
+          required: false,
         },
       ],
     },

--- a/src/constants/testSettingsPacket.js
+++ b/src/constants/testSettingsPacket.js
@@ -146,20 +146,6 @@ export default {
           type: 'string',
           required: true,
         },
-        // {
-        //   schema: {
-        //     description: 'date input',
-        //     label: 'Date Input',
-        //     category: '661661cd-a017-4796-ac4b-16a40b869daf',
-        //   },
-        //   displayType: 'date',
-        //   name: 'DATE',
-        //   multiple: false,
-        //   className: 'org.ecocean.MarkedIndividual',
-        //   id: 'c32e690c-e308-4362-82d5-bc97579e0abc',
-        //   type: 'string',
-        //   required: true,
-        // },
         {
           schema: {
             displayType: 'string',
@@ -188,7 +174,7 @@ export default {
           className: 'org.ecocean.MarkedIndividual',
           id: '1b62470c-890e-4665-8153-6ebefce10d189',
           type: 'double',
-          required: false,
+          required: true,
         },
       ],
     },

--- a/src/screens/newSighting/newSighting.jsx
+++ b/src/screens/newSighting/newSighting.jsx
@@ -163,21 +163,21 @@ const NewSighting = ({ navigation }) => {
             fieldsByCategory[category.label] = fields;
             customFields.push(category);
             headers.push(category.label);
-          }
-          if (categoryValidation) {
-            const test = categoryValidation.reduce(
-              (obj, item) => ({
-                ...obj,
-                [item[0]]:
-                  item[1] === 'string'
-                    ? yup.string().required('This is Required')
-                    : yup.number().required('This is Required'),
-              }),
-              {}
-            );
-            customRequiredFields.push(test);
-          } else {
-            customRequiredFields.push({});
+            if (categoryValidation) {
+              const test = categoryValidation.reduce(
+                (obj, item) => ({
+                  ...obj,
+                  [item[0]]:
+                    item[1] === 'string'
+                      ? yup.string().required('This is Required')
+                      : yup.number().required('This is Required'),
+                }),
+                {}
+              );
+              customRequiredFields.push(test);
+            } else {
+              customRequiredFields.push({});
+            }
           }
         }
       );


### PR DESCRIPTION
- Bug 1: Errors on custom fields were showing up before you reach the field (because the touched props were not getting updated as intended). Fix: Display the custom fields validation error on next button click.

- Bug 2: One of the screens was not getting validated, (because the form function was adding empty objects to the validation schema where it wasn’t needed). Fix: only add to the validation schema if that category is used.